### PR TITLE
Revert changes to support imapclient 1.0.

### DIFF
--- a/bin/contact-search-backfill
+++ b/bin/contact-search-backfill
@@ -2,7 +2,6 @@
 import click
 
 from gevent import monkey; monkey.patch_all()
-import gevent_openssl; gevent_openssl.monkey_patch()
 
 from inbox.contacts.search import index_namespace
 

--- a/bin/contact-search-service
+++ b/bin/contact-search-service
@@ -4,7 +4,6 @@ import os
 from setproctitle import setproctitle
 
 import click
-import gevent_openssl; gevent_openssl.monkey_patch()
 from gevent import monkey
 
 from inbox.config import config as inbox_config
@@ -14,7 +13,6 @@ from nylas.logging import configure_logging
 
 setproctitle('nylas-contact-search-index-service')
 monkey.patch_all()
-
 
 
 @click.command()

--- a/bin/inbox-api
+++ b/bin/inbox-api
@@ -15,8 +15,6 @@ except ImportError:
 
 from setproctitle import setproctitle; setproctitle('inbox-api')
 from gevent import monkey; monkey.patch_all()
-import gevent_openssl; gevent_openssl.monkey_patch()
-
 from gevent.pywsgi import WSGIServer
 
 from nylas.api.wsgi import NylasWSGIHandler

--- a/bin/inbox-auth
+++ b/bin/inbox-auth
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 from gevent import monkey; monkey.patch_all()
-import gevent_openssl; gevent_openssl.monkey_patch()
 import sys
 import click
 from setproctitle import setproctitle; setproctitle('inbox-auth')

--- a/bin/inbox-console
+++ b/bin/inbox-console
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 from gevent import monkey; monkey.patch_all()
-import gevent_openssl; gevent_openssl.monkey_patch()
 from setproctitle import setproctitle; setproctitle('inbox-console')
 
 import click

--- a/bin/inbox-start
+++ b/bin/inbox-start
@@ -2,9 +2,6 @@
 from gevent import monkey
 monkey.patch_all()
 
-import gevent_openssl
-gevent_openssl.monkey_patch()
-
 import os
 import socket
 import platform

--- a/bin/syncback-service
+++ b/bin/syncback-service
@@ -13,9 +13,6 @@ import click
 from gevent import monkey
 monkey.patch_all()
 
-import gevent_openssl
-gevent_openssl.monkey_patch()
-
 from nylas.logging import configure_logging
 
 from inbox.config import config as inbox_config

--- a/inbox/auth/generic.py
+++ b/inbox/auth/generic.py
@@ -1,6 +1,5 @@
 import datetime
 import getpass
-from backports import ssl
 from imapclient import IMAPClient
 import socket
 
@@ -8,6 +7,7 @@ from nylas.logging import get_logger
 log = get_logger()
 
 from inbox.auth.base import AuthHandler, account_or_none
+import inbox.auth.starttls  # noqa
 from inbox.basicauth import ValidationError, UserRecoverableConfigError
 from inbox.models import Namespace
 from inbox.models.backends.generic import GenericAccount
@@ -16,8 +16,6 @@ from inbox.sendmail.smtp.postel import SMTPClient
 
 PROVIDER = 'generic'
 AUTH_HANDLER_CLS = 'GenericAuthHandler'
-
-_ossl = ssl.ossl
 
 
 class GenericAuthHandler(AuthHandler):
@@ -68,7 +66,10 @@ class GenericAuthHandler(AuthHandler):
         """
         host, port = account.imap_endpoint
         try:
-            conn = create_imap_connection(host, port)
+            conn = IMAPClient(host, port=port, use_uid=True, ssl=(port == 993))
+            if port != 993:
+                # Raises an exception if TLS can't be established
+                conn._imap.starttls()
         except (IMAPClient.Error, socket.error) as exc:
             log.error('Error instantiating IMAP connection',
                       account_id=account.id,
@@ -213,53 +214,3 @@ def _auth_is_invalid(exc):
     )
     return any(exc.message.lower().startswith(msg) for msg in
                AUTH_INVALID_PREFIXES)
-
-
-def create_imap_connection(host, port):
-    use_ssl = port == 993
-
-    # TODO: certificate pinning for well known sites
-    context = create_default_context()
-
-    conn = IMAPClient(host, port=port, use_uid=True,
-                      ssl=use_ssl, ssl_context=context, timeout=120)
-    if not use_ssl:
-        # Raises an exception if TLS can't be established
-        conn.starttls(context)
-    return conn
-
-
-def create_default_context():
-    """Return a backports.ssl.SSLContext object configured with sensible
-    default settings. This was adapted from imapclient.create_default_context
-    to allow all ciphers and disable certificate verification.
-
-    """
-    # adapted from Python 3.4's ssl.create_default_context
-
-    context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
-
-    # do not verify that certificate is signed nor that the
-    # certificate matches the hostname
-    context.verify_mode = ssl.CERT_NONE
-    context.check_hostname = False
-
-    # SSLv2 considered harmful.
-    context.options |= _ossl.OP_NO_SSLv2
-
-    # SSLv3 has problematic security and is only required for really old
-    # clients such as IE6 on Windows XP
-    context.options |= _ossl.OP_NO_SSLv3
-
-    # disable compression to prevent CRIME attacks (OpenSSL 1.0+)
-    context.options |= getattr(_ossl, "OP_NO_COMPRESSION", 0)
-
-    # Prefer the server's ciphers by default so that we get stronger
-    # encryption
-    context.options |= getattr(_ossl, "OP_CIPHER_SERVER_PREFERENCE", 0)
-
-    # Use single use keys in order to improve forward secrecy
-    context.options |= getattr(_ossl, "OP_SINGLE_DH_USE", 0)
-    context.options |= getattr(_ossl, "OP_SINGLE_ECDH_USE", 0)
-
-    return context

--- a/inbox/auth/oauth.py
+++ b/inbox/auth/oauth.py
@@ -8,7 +8,6 @@ from imapclient import IMAPClient
 from nylas.logging import get_logger
 log = get_logger()
 from inbox.auth.base import AuthHandler
-from inbox.auth.generic import create_imap_connection
 from inbox.basicauth import ConnectionError, OAuthError
 from inbox.models.backends.oauth import token_manager
 
@@ -37,7 +36,7 @@ class OAuthAuthHandler(AuthHandler):
     def _get_IMAP_connection(self, account):
         host, port = account.imap_endpoint
         try:
-            conn = create_imap_connection(host, port)
+            conn = IMAPClient(host, port=port, use_uid=True, ssl=True)
         except (IMAPClient.Error, socket.error) as exc:
             log.error('Error instantiating IMAP connection',
                       account_id=account.id,

--- a/inbox/auth/starttls.py
+++ b/inbox/auth/starttls.py
@@ -1,0 +1,47 @@
+# Backport from Python 3.2
+# Custom SSLContext may be passed starting from Python 2.7.9.
+# http://hg.python.org/cpython/rev/8d6516949a71/
+import imaplib
+import ssl
+
+Commands = {
+    'STARTTLS': ('NONAUTH',)
+}
+imaplib.Commands.update(Commands)
+
+
+def starttls(self, ssl_context=None):
+    name = 'STARTTLS'
+    if self._tls_established:
+        raise self.abort('TLS session already established')
+    if name not in self.capabilities:
+        raise self.abort('TLS not supported by server')
+    # Generate a default SSL context if none was passed.
+    if ssl_context is None:
+        try:
+            ssl_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+        except AttributeError:
+            # Python < 2.7.9
+            ssl_context = None
+        else:
+            # SSLv2 considered harmful.
+            ssl_context.options |= ssl.OP_NO_SSLv2
+    # Generate a default SSL context if none was passed.
+    typ, dat = self._simple_command(name)
+    if typ == 'OK':
+        if ssl_context:
+            self.sock = ssl_context.wrap_socket(self.sock)
+        else:
+            self.sock = ssl.wrap_socket(self.sock)
+        self.file = self.sock.makefile('rb')
+        self._tls_established = True
+        typ, dat = self.capability()
+        if dat == [None]:
+            raise self.error('no CAPABILITY response from server')
+        self.capabilities = tuple(dat[-1].upper().split())
+    else:
+        raise self.error("Couldn't establish TLS session")
+    return self._untagged_response(typ, dat, name)
+
+imaplib.IMAP4._tls_established = False
+imaplib.IMAP4.starttls = starttls

--- a/inbox/mailsync/backends/gmail.py
+++ b/inbox/mailsync/backends/gmail.py
@@ -204,16 +204,15 @@ class GmailFolderSyncEngine(FolderSyncEngine):
                 # Prioritize UIDs for messages in the inbox folder.
                 if len(remote_uids) < 1e6:
                     inbox_uids = set(
-                        crispin_client.search_uids(['X-GM-LABELS', 'inbox']))
+                        crispin_client.search_uids(['X-GM-LABELS inbox']))
                 else:
                     # The search above is really slow (times out) on really
                     # large mailboxes, so bound the search to messages within
                     # the past month in order to get anywhere.
-                    since = datetime.utcnow() - timedelta(days=30)
-                    inbox_uids = set(crispin_client.search_uids([
-                        'X-GM-LABELS', 'inbox',
-                        'SINCE', since]))
-
+                    since = (datetime.utcnow() - timedelta(days=30)). \
+                        strftime('%d-%b-%Y')
+                    inbox_uids = set(crispin_client.search_uids(
+                        ['X-GM-LABELS inbox', 'SINCE {}'.format(since)]))
                 uids_to_download = (sorted(unknown_uids - inbox_uids) +
                                     sorted(unknown_uids & inbox_uids))
             else:

--- a/inbox/util/consistency_check/imap_gm.py
+++ b/inbox/util/consistency_check/imap_gm.py
@@ -17,7 +17,7 @@ import json
 from StringIO import StringIO
 from flanker.mime.message.headers import MimeHeaders
 from flanker.mime.message.headers.parsing import parse_header_value
-from inbox.auth.generic import create_imap_connection
+from imapclient import IMAPClient
 from inbox.util.addr import parse_email_address_list
 from inbox.util.misc import cleanup_subject
 
@@ -44,7 +44,7 @@ class ImapGmailPlugin(DumpGmailMixin):
         info = account.provider_info
         host, port = account.imap_endpoint
 
-        imap = create_imap_connection(host, port)
+        imap = IMAPClient(host, port=port, use_uid=True, ssl=True)
         imap.debug = self.args.debug_imap
         if info['auth'] == 'oauth2':
             imap.oauth2_login(account.email_address, account.access_token)

--- a/inbox/util/rdb.py
+++ b/inbox/util/rdb.py
@@ -2,8 +2,6 @@ import socket
 import sys
 from gevent import monkey
 monkey.patch_all(aggressive=False)
-import gevent_openssl
-gevent_openssl.monkey_patch()
 from code import InteractiveConsole
 from nylas.logging import get_logger
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ setproctitle==1.1.8
 gdata==2.0.18
 git+https://github.com/nylas/dateutil.git#egg=python-dateutil
 git+https://github.com/khamidou/flanker.git#egg=flanker
-imapclient==1.0.0
+hg+https://bitbucket.org/mjs0/imapclient@2290a2ab355484#egg=imapclient
 alembic==0.6.5
 iconv==1.0
 pep8==1.4.6
@@ -54,6 +54,3 @@ hypothesis==1.10.3
 statsd==3.1
 boto3==1.1.4
 Pympler==0.4.2
-pyopenssl>=0.15.1
-gevent_openssl==1.2
-git+https://github.com/alekstorm/backports.ssl.git#egg=backports.ssl

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "simplejson>=3.6.0",
         "icalendar>=3.8.2",
         "simplejson>=3.6.0",
+        "imapclient==0.13",
         "Flask>=0.10.1",
         "Flask-RESTful==0.3.2",
         "pynacl>=0.2.3",
@@ -41,15 +42,9 @@ setup(
         "arrow==0.5.4",
         "statsd>=3.1",
         "boto3>=1.1.4",
-        "Pympler==0.4.2",
-        "pyopenssl>=0.15.1",
-        "gevent_openssl==1.2",
-        "backports.ssl>=0.0.7",
-        "imapclient==1.0.0",
+        "Pympler==0.4.2"
     ],
-    dependency_links=[
-        "git+https://github.com/alekstorm/backports.ssl.git#egg=backports.ssl"
-    ],
+    dependency_links=[],
 
     include_package_data=True,
     package_data={

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -3,6 +3,3 @@
 # attribute 'poll'" errors when tests import socket, then monkeypatch.
 from gevent import monkey
 monkey.patch_all(aggressive=False)
-
-import gevent_openssl
-gevent_openssl.monkey_patch()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,4 @@
 # attribute 'poll'" errors when tests import socket, then monkeypatch.
 from gevent import monkey
 monkey.patch_all(aggressive=False)
-
-import gevent_openssl
-gevent_openssl.monkey_patch()
-
 from tests.util.base import *

--- a/tests/imap/data.py
+++ b/tests/imap/data.py
@@ -105,24 +105,25 @@ class MockIMAPClient(object):
 
     def search(self, criteria):
         assert self.selected_folder is not None
-        assert isinstance(criteria, list)
         uid_dict = self._data[self.selected_folder]
         if criteria == ['ALL']:
             return uid_dict.keys()
-        if criteria == ['X-GM-LABELS', 'inbox']:
+        if criteria == ['X-GM-LABELS inbox']:
             return [k for k, v in uid_dict.items()
                     if ('\\Inbox,') in v['X-GM-LABELS']]
-        if criteria[0] == 'HEADER':
-            name, value = criteria[1:]
+
+        m = re.match('HEADER (?P<name>[a-zA-Z-]+) (?P<value>.+)', criteria[0])
+        if m:
+            name = m.group('name').lower()
+            value = m.group('value').lower()
             headerstring = '{}: {}'.format(name, value)
             # Slow implementation, but whatever
             return [u for u, v in uid_dict.items() if headerstring in
                     v['BODY[]'].lower()]
-        if criteria[0] == 'X-GM-THRID':
-            assert len(criteria) == 2
-            thrid = criteria[1]
+
+        if re.match('X-GM-THRID [0-9]*', criteria[0]):
+            thrid = int(criteria[0].split()[1])
             return [u for u, v in uid_dict.items() if v['X-GM-THRID'] == thrid]
-        raise ValueError('unsupported test criteria: {!r}'.format(criteria))
 
     def select_folder(self, folder_name, readonly=False):
         self.selected_folder = folder_name

--- a/tests/imap/test_pooling.py
+++ b/tests/imap/test_pooling.py
@@ -1,11 +1,7 @@
 import imaplib
-import socket
-
 import gevent
 import pytest
 import mock
-from backports import ssl
-
 from inbox.crispin import CrispinConnectionPool
 
 
@@ -34,25 +30,17 @@ def test_block_on_depleted_pool():
                 pass
 
 
-@pytest.mark.parametrize("error_class,expect_logout_called", [
-    (imaplib.IMAP4.error, True),
-    (imaplib.IMAP4.abort, False),
-    (socket.error, False),
-    (socket.timeout, False),
-    (ssl.SSLError, False),
-    (ssl.CertificateError, False),
-])
-def test_imap_and_network_errors(error_class, expect_logout_called):
+def test_connection_discarded_on_imap_errors():
     pool = TestableConnectionPool(1, num_connections=3, readonly=True)
-    with pytest.raises(error_class):
+    with pytest.raises(imaplib.IMAP4.error):
         with pool.get() as conn:
-            raise error_class
+            raise imaplib.IMAP4.error
     assert pool._queue.full()
     # Check that the connection wasn't returned to the pool
     while not pool._queue.empty():
         item = pool._queue.get()
         assert item is None
-    assert conn.logout.called is expect_logout_called
+    assert conn.logout.called
 
 
 def test_connection_retained_on_other_errors():
@@ -61,4 +49,4 @@ def test_connection_retained_on_other_errors():
         with pool.get() as conn:
             raise ValueError
     assert conn in pool._queue
-    assert not conn.logout.called
+    assert conn.logout.called == False

--- a/tests/system/test_labels.py
+++ b/tests/system/test_labels.py
@@ -45,7 +45,7 @@ def test_gmail_labels(client):
             crispin_client.select_folder(folder_name, uidvalidity_cb)
 
             print "Subject : %s" % thread.subject
-            uids = crispin_client.search_uids(['SUBJECT', thread.subject])
+            uids = crispin_client.search_uids(['SUBJECT "%s"' % thread.subject])
             g_thrid = crispin_client.g_metadata(uids).items()[0][1].thrid
 
             crispin_client.add_label(g_thrid, labelname)


### PR DESCRIPTION
Reason for rollback: blocking in gevent_openssl.

This reverts commits:
b13d8818bad94448b2922b3bf00203d4361c6c52
492991fcb082a2da49c2c2e87efffe38c3607878
d438e818f05f812245deaf302c29034cc07163d9
7a77e175eb4d925b58d300078bf02a5e20dad0a9
34e45dd0b5ce69446d6f373d0fe85d408adcc242
5b1c229c28ff9e017e8dc00413d3e01ceb25da0a
d5795a22696ff2e16e8c62bffccde2c90853c42c
1e050a6af342d1e8ea43cf943dcd1cab5df8fa28
66956f7e2cb7e726885d730daff2cd72896bd75bsync-engine